### PR TITLE
Camel spring boot examples for apm opentrace

### DIFF
--- a/camel-example-spring-boot-apm-opentracing/README.adoc
+++ b/camel-example-spring-boot-apm-opentracing/README.adoc
@@ -1,0 +1,48 @@
+== OpenTracing Example
+
+=== Introduction
+
+This example shows how to use Camel with OpenTracing to trace all
+incoming and outgoing Camel messages.
+
+The example uses a ElastiCo APM Client.
+
+Route client -> service1 using HTTP.
+
+=== Before you start
+
+You need to configure EAK stack - Elasticsearch, APM Server and Kibana
+Please follow https://www.elastic.co/guide/en/apm/get-started/current/install-and-run.html to get up and running
+
+=== Build
+
+You will need to compile this example first:
+
+[source,sh]
+----
+$ mvn compile
+----
+
+=== Run the example
+
+[source,sh]
+----
+$ mvn compile spring-boot:run
+
+The client application explicitly instantiates and initializes the
+implementation
+
+=== View results
+After seeing in console messages from timer, visit Kibana to view traces -
+http://localhost:5601/app/apm#/services/Service1Application/transactions/
+select any transaction and click "View full trace"
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/support.html[let us know].
+
+We also love contributors, so
+https://camel.apache.org/contributing.html[get involved] :-)
+
+The Camel riders!

--- a/camel-example-spring-boot-apm-opentracing/pom.xml
+++ b/camel-example-spring-boot-apm-opentracing/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.springboot.example</groupId>
+        <artifactId>examples</artifactId>
+        <version>3.5.0</version>
+    </parent>
+
+    <artifactId>camel-example-spring-boot-apm-opentracing</artifactId>
+    <packaging>pom</packaging>
+    <name>Camel SB Examples :: OpenTracing APM</name>
+    <description>An example showing how to trace incoming and outgoing messages from Camel with OpenTracing with ElastiCo APM
+    </description>
+
+    <properties>
+        <category>Management and Monitoring</category>
+        <title>OpenTracing APM</title>
+        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+    </properties>
+
+
+    <!-- import Spring-Boot and Camel BOM -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-dependencies</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <!-- spring-boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+            <version>${spring.boot-version}</version>
+        </dependency>
+
+        <!-- camel -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-opentracing-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-jetty-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-http-starter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <!-- CDI API -->
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>${cdi-api-2.0-version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- elastico -->
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-agent-attach</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-opentracing</artifactId>
+            <version>1.18.0</version>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/camel-example-spring-boot-apm-opentracing/pom.xml
+++ b/camel-example-spring-boot-apm-opentracing/pom.xml
@@ -91,14 +91,6 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 
-        <!-- CDI API -->
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>${cdi-api-2.0-version}</version>
-            <scope>provided</scope>
-        </dependency>
-
         <!-- elastico -->
         <dependency>
             <groupId>co.elastic.apm</groupId>

--- a/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/CamelConfig.java
+++ b/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/CamelConfig.java
@@ -1,0 +1,18 @@
+package sample.camel;
+
+import co.elastic.apm.opentracing.ElasticApmTracer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class CamelConfig {
+    @Bean
+    public ElasticApmTracer tracer() {
+        return new ElasticApmTracer();
+    }
+
+    @Bean
+    public CounterBean counterBean() {
+        return new CounterBean();
+    }
+}

--- a/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/CamelConfig.java
+++ b/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/CamelConfig.java
@@ -1,3 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package sample.camel;
 
 import co.elastic.apm.opentracing.ElasticApmTracer;

--- a/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/CounterBean.java
+++ b/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/CounterBean.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+public class CounterBean {
+
+    private int counter;
+
+    public String someMethod(String body) {
+        return "" + ++counter;
+    }
+}

--- a/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/Service1Application.java
+++ b/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/Service1Application.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import co.elastic.apm.attach.ElasticApmAttacher;
+import org.apache.camel.opentracing.starter.CamelOpenTracing;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * A Spring Boot application that starts the Camel OpenTracing application.
+ * <p/>
+ * Notice we use the `@CamelOpenTracing` annotation to enable Camel with OpenTracing.
+ */
+@SpringBootApplication
+@CamelOpenTracing
+public class Service1Application {
+    /**
+     * A main method to start this application.
+     */
+
+    public static void main(String[] args) {
+        ElasticApmAttacher.attach();
+        SpringApplication.run(Service1Application.class, args);
+    }
+
+
+}

--- a/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/Service1Application.java
+++ b/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/Service1Application.java
@@ -25,6 +25,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
  * A Spring Boot application that starts the Camel OpenTracing application.
  * <p/>
  * Notice we use the `@CamelOpenTracing` annotation to enable Camel with OpenTracing.
+ * Also we start APM Agent with `ElasticApmAttacher.attach()`
  */
 @SpringBootApplication
 @CamelOpenTracing
@@ -32,11 +33,8 @@ public class Service1Application {
     /**
      * A main method to start this application.
      */
-
     public static void main(String[] args) {
         ElasticApmAttacher.attach();
         SpringApplication.run(Service1Application.class, args);
     }
-
-
 }

--- a/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/Service1Route.java
+++ b/camel-example-spring-boot-apm-opentracing/src/main/java/sample/camel/Service1Route.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class Service1Route extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+         from("timer:trigger?exchangePattern=InOut&period=30000").streamCaching()
+            .bean("counterBean")
+            .log(" Client request: ${body}")
+            .to("http://localhost:9090/service1")
+            .log("Client response: ${body}");
+
+        from("jetty:http://0.0.0.0:9090/service1").routeId("service1").streamCaching()
+            .removeHeaders("CamelHttp*")
+            .log("Service1 request: ${body}")
+            .delay(simple("${random(1000,2000)}"))
+            .transform(simple("Service1-${body}"))
+            .log("Service1 response: ${body}");
+    }
+
+}

--- a/camel-example-spring-boot-apm-opentracing/src/main/resources/application.properties
+++ b/camel-example-spring-boot-apm-opentracing/src/main/resources/application.properties
@@ -1,0 +1,26 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+# the name of Camel
+camel.springboot.name=Service1
+camel.springboot.main-run-controller=true
+
+# the port number the service will use for accepting incoming HTTP requests
+service1.port=9090
+
+logging.level.org.apache.camel=DEBUG
+logging.level.opentracing.level = DEBUG

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <module>camel-example-spring-boot</module>
         <module>camel-example-spring-boot-activemq</module>
         <module>camel-example-spring-boot-amqp</module>
+        <module>camel-example-spring-boot-apm-opentracing</module>
         <module>camel-example-spring-boot-arangodb</module>
         <module>camel-example-spring-boot-clustered-route-controller</module>
         <module>camel-example-spring-boot-fhir</module>


### PR DESCRIPTION
This pull request contains example for configuring https://camel.apache.org/components/latest/others/opentracing.html to work with ElasticCo Aplication Perfomance Manger Server - https://www.elastic.co/guide/en/apm/get-started/current/install-and-run.html