### PR TITLE
Fix tag 3.5.0 so it's buildable

### DIFF
--- a/camel-example-spring-boot-activemq/pom.xml
+++ b/camel-example-spring-boot-activemq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-activemq</artifactId>

--- a/camel-example-spring-boot-amqp/pom.xml
+++ b/camel-example-spring-boot-amqp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-amqp</artifactId>

--- a/camel-example-spring-boot-arangodb/pom.xml
+++ b/camel-example-spring-boot-arangodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-arangodb</artifactId>

--- a/camel-example-spring-boot-clustered-route-controller/cluster-bootstrap/pom.xml
+++ b/camel-example-spring-boot-clustered-route-controller/cluster-bootstrap/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-clustered-route-controller</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-clustered-route-controller-cluster-bootstrap</artifactId>

--- a/camel-example-spring-boot-clustered-route-controller/cluster-node/pom.xml
+++ b/camel-example-spring-boot-clustered-route-controller/cluster-node/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-clustered-route-controller</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-clustered-route-controller-cluster-node</artifactId>

--- a/camel-example-spring-boot-clustered-route-controller/pom.xml
+++ b/camel-example-spring-boot-clustered-route-controller/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-clustered-route-controller</artifactId>

--- a/camel-example-spring-boot-fhir-auth-tx/pom.xml
+++ b/camel-example-spring-boot-fhir-auth-tx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-fhir-auth-tx</artifactId>

--- a/camel-example-spring-boot-fhir/pom.xml
+++ b/camel-example-spring-boot-fhir/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-fhir</artifactId>

--- a/camel-example-spring-boot-geocoder/pom.xml
+++ b/camel-example-spring-boot-geocoder/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-geocoder</artifactId>

--- a/camel-example-spring-boot-grpc-kubernetes/hello-camel-grpc-client-kubernetes/pom.xml
+++ b/camel-example-spring-boot-grpc-kubernetes/hello-camel-grpc-client-kubernetes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-grpc-kubernetes</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-hello-grpc-client-kubernetes</artifactId>

--- a/camel-example-spring-boot-grpc-kubernetes/hello-camel-grpc-server-kubernetes/pom.xml
+++ b/camel-example-spring-boot-grpc-kubernetes/hello-camel-grpc-server-kubernetes/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-grpc-kubernetes</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-hello-grpc-server-kubernetes</artifactId>

--- a/camel-example-spring-boot-grpc-kubernetes/pom.xml
+++ b/camel-example-spring-boot-grpc-kubernetes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-grpc-kubernetes</artifactId>

--- a/camel-example-spring-boot-grpc/hello-camel-grpc-client/pom.xml
+++ b/camel-example-spring-boot-grpc/hello-camel-grpc-client/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-grpc</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-hello-grpc-client</artifactId>

--- a/camel-example-spring-boot-grpc/hello-camel-grpc-server/pom.xml
+++ b/camel-example-spring-boot-grpc/hello-camel-grpc-server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-grpc</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-hello-grpc-server</artifactId>

--- a/camel-example-spring-boot-grpc/pom.xml
+++ b/camel-example-spring-boot-grpc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-grpc</artifactId>

--- a/camel-example-spring-boot-health-checks/pom.xml
+++ b/camel-example-spring-boot-health-checks/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-health-checks</artifactId>

--- a/camel-example-spring-boot-hystrix/client/pom.xml
+++ b/camel-example-spring-boot-hystrix/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-hystrix</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-hystrix-client</artifactId>

--- a/camel-example-spring-boot-hystrix/pom.xml
+++ b/camel-example-spring-boot-hystrix/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-hystrix</artifactId>

--- a/camel-example-spring-boot-hystrix/service1/pom.xml
+++ b/camel-example-spring-boot-hystrix/service1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-hystrix</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-hystrix-service1</artifactId>

--- a/camel-example-spring-boot-hystrix/service2/pom.xml
+++ b/camel-example-spring-boot-hystrix/service2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-hystrix</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-hystrix-service2</artifactId>

--- a/camel-example-spring-boot-infinispan/pom.xml
+++ b/camel-example-spring-boot-infinispan/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-infinispan</artifactId>

--- a/camel-example-spring-boot-jira/pom.xml
+++ b/camel-example-spring-boot-jira/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-jira</artifactId>

--- a/camel-example-spring-boot-kafka-avro/pom.xml
+++ b/camel-example-spring-boot-kafka-avro/pom.xml
@@ -23,7 +23,7 @@
   <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
   <artifactId>camel-example-spring-boot-kafka-avro</artifactId>

--- a/camel-example-spring-boot-kafka-offsetrepository/pom.xml
+++ b/camel-example-spring-boot-kafka-offsetrepository/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-kafka-offsetrepository</artifactId>

--- a/camel-example-spring-boot-master/pom.xml
+++ b/camel-example-spring-boot-master/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-master</artifactId>

--- a/camel-example-spring-boot-metrics/pom.xml
+++ b/camel-example-spring-boot-metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-metrics</artifactId>

--- a/camel-example-spring-boot-opentracing/client/pom.xml
+++ b/camel-example-spring-boot-opentracing/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-opentracing</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-opentracing-client</artifactId>

--- a/camel-example-spring-boot-opentracing/loggingtracer/pom.xml
+++ b/camel-example-spring-boot-opentracing/loggingtracer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-opentracing</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-opentracing-loggingtracer</artifactId>

--- a/camel-example-spring-boot-opentracing/pom.xml
+++ b/camel-example-spring-boot-opentracing/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-opentracing</artifactId>

--- a/camel-example-spring-boot-opentracing/service1/pom.xml
+++ b/camel-example-spring-boot-opentracing/service1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-opentracing</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-opentracing-service1</artifactId>

--- a/camel-example-spring-boot-opentracing/service2/pom.xml
+++ b/camel-example-spring-boot-opentracing/service2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-opentracing</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-opentracing-service2</artifactId>

--- a/camel-example-spring-boot-pojo/pom.xml
+++ b/camel-example-spring-boot-pojo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-pojo</artifactId>

--- a/camel-example-spring-boot-rabbitmq/pom.xml
+++ b/camel-example-spring-boot-rabbitmq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rabbitmq</artifactId>

--- a/camel-example-spring-boot-reactive-streams/pom.xml
+++ b/camel-example-spring-boot-reactive-streams/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-reactive-streams</artifactId>

--- a/camel-example-spring-boot-resilience4j/client/pom.xml
+++ b/camel-example-spring-boot-resilience4j/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-resilience4j</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-client</artifactId>

--- a/camel-example-spring-boot-resilience4j/client2/pom.xml
+++ b/camel-example-spring-boot-resilience4j/client2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-resilience4j</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-client2</artifactId>

--- a/camel-example-spring-boot-resilience4j/pom.xml
+++ b/camel-example-spring-boot-resilience4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j</artifactId>

--- a/camel-example-spring-boot-resilience4j/service1/pom.xml
+++ b/camel-example-spring-boot-resilience4j/service1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-resilience4j</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-service1</artifactId>

--- a/camel-example-spring-boot-resilience4j/service2/pom.xml
+++ b/camel-example-spring-boot-resilience4j/service2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-resilience4j</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-service2</artifactId>

--- a/camel-example-spring-boot-rest-jpa/pom.xml
+++ b/camel-example-spring-boot-rest-jpa/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-jpa</artifactId>

--- a/camel-example-spring-boot-rest-openapi-simple/pom.xml
+++ b/camel-example-spring-boot-rest-openapi-simple/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-openapi-simple</artifactId>

--- a/camel-example-spring-boot-rest-openapi/pom.xml
+++ b/camel-example-spring-boot-rest-openapi/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-openapi</artifactId>

--- a/camel-example-spring-boot-rest-producer/pom.xml
+++ b/camel-example-spring-boot-rest-producer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-producer</artifactId>

--- a/camel-example-spring-boot-rest-swagger-simple/pom.xml
+++ b/camel-example-spring-boot-rest-swagger-simple/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-swagger-simple</artifactId>

--- a/camel-example-spring-boot-rest-swagger/pom.xml
+++ b/camel-example-spring-boot-rest-swagger/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-swagger</artifactId>

--- a/camel-example-spring-boot-servicecall/consumer/pom.xml
+++ b/camel-example-spring-boot-servicecall/consumer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-servicecall</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-servicecall-consumer</artifactId>

--- a/camel-example-spring-boot-servicecall/pom.xml
+++ b/camel-example-spring-boot-servicecall/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-servicecall</artifactId>

--- a/camel-example-spring-boot-servicecall/services/pom.xml
+++ b/camel-example-spring-boot-servicecall/services/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-servicecall</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-servicecall-services</artifactId>

--- a/camel-example-spring-boot-strimzi/pom.xml
+++ b/camel-example-spring-boot-strimzi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>examples</artifactId>
-		<version>3.5.0-SNAPSHOT</version>
+		<version>3.5.0</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-strimzi</artifactId>

--- a/camel-example-spring-boot-supervising-route-controller/pom.xml
+++ b/camel-example-spring-boot-supervising-route-controller/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-supervising-route-controller</artifactId>

--- a/camel-example-spring-boot-twitter-salesforce/pom.xml
+++ b/camel-example-spring-boot-twitter-salesforce/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-twitter-salesforce</artifactId>

--- a/camel-example-spring-boot-undertow-spring-security/pom.xml
+++ b/camel-example-spring-boot-undertow-spring-security/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.apache.camel.springboot.example</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-example-spring-boot-validator/pom.xml
+++ b/camel-example-spring-boot-validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-validator</artifactId>

--- a/camel-example-spring-boot-webhook/pom.xml
+++ b/camel-example-spring-boot-webhook/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.apache.camel.springboot.example</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-example-spring-boot-widget-gadget/pom.xml
+++ b/camel-example-spring-boot-widget-gadget/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.apache.camel.springboot.example</groupId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/camel-example-spring-boot-xml/pom.xml
+++ b/camel-example-spring-boot-xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-xml</artifactId>

--- a/camel-example-spring-boot-zipkin/client/pom.xml
+++ b/camel-example-spring-boot-zipkin/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-zipkin</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-zipkin-client</artifactId>

--- a/camel-example-spring-boot-zipkin/pom.xml
+++ b/camel-example-spring-boot-zipkin/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-zipkin</artifactId>

--- a/camel-example-spring-boot-zipkin/service1/pom.xml
+++ b/camel-example-spring-boot-zipkin/service1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-zipkin</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-zipkin-service1</artifactId>

--- a/camel-example-spring-boot-zipkin/service2/pom.xml
+++ b/camel-example-spring-boot-zipkin/service2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-zipkin</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-zipkin-service2</artifactId>

--- a/camel-example-spring-boot/pom.xml
+++ b/camel-example-spring-boot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-boot</artifactId>

--- a/camel-example-spring-cloud-servicecall/consumer/pom.xml
+++ b/camel-example-spring-cloud-servicecall/consumer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-cloud-servicecall</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-cloud-servicecall-consumer</artifactId>

--- a/camel-example-spring-cloud-servicecall/pom.xml
+++ b/camel-example-spring-cloud-servicecall/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-cloud-servicecall</artifactId>

--- a/camel-example-spring-cloud-servicecall/service/pom.xml
+++ b/camel-example-spring-cloud-servicecall/service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-cloud-servicecall</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-cloud-servicecall-service</artifactId>

--- a/camel-example-spring-cloud-serviceregistry/consumer/pom.xml
+++ b/camel-example-spring-cloud-serviceregistry/consumer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-cloud-serviceregistry</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-cloud-serviceregistry-consumer</artifactId>

--- a/camel-example-spring-cloud-serviceregistry/pom.xml
+++ b/camel-example-spring-cloud-serviceregistry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-cloud-serviceregistry</artifactId>

--- a/camel-example-spring-cloud-serviceregistry/service/pom.xml
+++ b/camel-example-spring-cloud-serviceregistry/service/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-cloud-serviceregistry</artifactId>
-        <version>3.5.0-SNAPSHOT</version>
+        <version>3.5.0</version>
     </parent>
 
     <artifactId>camel-example-spring-cloud-serviceregistry-service</artifactId>


### PR DESCRIPTION
Hi,

This branch fixes tag camel-spring-boot-examples-3.5.0 so it's buildable.

Although git allows me to compare to tags, it doesn't allow me to submit PR's to said tags, so I have put master to be able to submit the PR.

I'm not sure what would be the approach to fix the tag, but I think it's out of the scope of my possibilities. I hope you can use this to apply a patch or something

Thank you