### PR TITLE
CAMEL-15323: Add example camel-spring-boot - http endpoint for route information

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -35,6 +35,8 @@ Number of Examples: 43 (0 deprecated)
 
 | link:camel-example-spring-boot-health-checks/readme.adoc[Spring Boot Health Checks] (camel-example-spring-boot-health-checks) |  |
 
+| link:camel-example-spring-boot-actuator-http-metrics/readme.adoc[Spring Boot Actuator HTTP Metrics] (camel-example-spring-boot-actuator-http-metrics) | Beginner | Example on how to use Spring Boot's Actuator endpoints to gather info like mappings or metrics
+
 | link:camel-example-spring-boot-undertow-spring-security/readme.adoc[Spring Boot Undertow Spring Security] (camel-example-spring-boot-undertow-spring-security) | Advanced | Example on how to use the Camel Undertow component with spring security and Keycloak
 
 | link:camel-example-spring-boot-webhook/readme.adoc[Spring Boot Webhook] (camel-example-spring-boot-webhook) | Advanced | Example on how to use the Camel Webhook component

--- a/README.adoc
+++ b/README.adoc
@@ -27,21 +27,21 @@ readme's instructions.
 == Examples
 
 // examples: START
-Number of Examples: 43 (0 deprecated)
+Number of Examples: 44 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
 | Example | Category | Description
 
-| link:camel-example-spring-boot-health-checks/readme.adoc[Spring Boot Health Checks] (camel-example-spring-boot-health-checks) |  |
-
-| link:camel-example-spring-boot-actuator-http-metrics/readme.adoc[Spring Boot Actuator HTTP Metrics] (camel-example-spring-boot-actuator-http-metrics) | Beginner | Example on how to use Spring Boot's Actuator endpoints to gather info like mappings or metrics
+| link:camel-example-spring-boot-health-checks/readme.adoc[Spring Boot Health Checks] (camel-example-spring-boot-health-checks) |  | 
 
 | link:camel-example-spring-boot-undertow-spring-security/readme.adoc[Spring Boot Undertow Spring Security] (camel-example-spring-boot-undertow-spring-security) | Advanced | Example on how to use the Camel Undertow component with spring security and Keycloak
 
 | link:camel-example-spring-boot-webhook/readme.adoc[Spring Boot Webhook] (camel-example-spring-boot-webhook) | Advanced | Example on how to use the Camel Webhook component
 
 | link:camel-example-spring-boot/readme.adoc[Spring Boot] (camel-example-spring-boot) | Beginner | An example showing how to work with Camel and Spring Boot
+
+| link:camel-example-spring-boot-actuator-http-metrics/readme.adoc[Spring Boot Actuator Http Metrics] (camel-example-spring-boot-actuator-http-metrics) | Beginner | Example on how to use Spring Boot's Actuator endpoints to gather info like mappings or metrics
 
 | link:camel-example-spring-boot-jira/README.adoc[Spring Boot Jira] (camel-example-spring-boot-jira) | Beginner | An example that uses Jira Camel API
 
@@ -74,8 +74,8 @@ Number of Examples: 43 (0 deprecated)
 | link:camel-example-spring-boot-arangodb/README.adoc[Spring Boot Arangodb] (camel-example-spring-boot-arangodb) | Database | An example showing the Camel ArangoDb component with Spring Boot
 
 | link:camel-example-spring-boot-rest-jpa/README.adoc[Spring Boot REST JPA] (camel-example-spring-boot-rest-jpa) | Database | An example demonstrating how to use Camel REST DSL with JPA to expose a RESTful API that performs CRUD
-operations on a database
-
+        operations on a database
+    
 
 | link:camel-example-spring-boot-hystrix/README.adoc[Spring Boot Hystrix] (camel-example-spring-boot-hystrix) | EIP | An example showing how to use Hystrix EIP as circuit breaker in Camel routes
 
@@ -84,17 +84,17 @@ operations on a database
 | link:camel-example-spring-boot-fhir/readme.adoc[Spring Boot Fhir] (camel-example-spring-boot-fhir) | Health Care | An example showing how to work with Camel, FHIR and Spring Boot
 
 | link:camel-example-spring-boot-fhir-auth-tx/readme.adoc[Spring Boot Fhir Auth Tx] (camel-example-spring-boot-fhir-auth-tx) | Health Care | An example showing how to work with Camel, FHIR Authorization, FHIR Transaction and Spring Boot
-
+    
 
 | link:camel-example-spring-boot-validator/readme.adoc[Validator Spring Boot] (camel-example-spring-boot-validator) | Input/Output Type Contract | An example showing how to work with declarative validation and Spring Boot
 
 | link:camel-example-spring-boot-apm-opentracing/README.adoc[OpenTracing APM] (camel-example-spring-boot-apm-opentracing) | Management and Monitoring | An example showing how to trace incoming and outgoing messages from Camel with OpenTracing with ElastiCo APM
-
+    
 
 | link:camel-example-spring-boot-metrics/README.adoc[Spring Boot Metrics] (camel-example-spring-boot-metrics) | Management and Monitoring | An example showing how to work with Camel and Spring Boot and report metrics to Graphite
 
 | link:camel-example-spring-boot-opentracing/README.adoc[OpenTracing] (camel-example-spring-boot-opentracing) | Management and Monitoring | An example showing how to trace incoming and outgoing messages from Camel with OpenTracing
-
+    
 
 | link:camel-example-spring-boot-supervising-route-controller/readme.adoc[Spring Boot Supervising Route Controller] (camel-example-spring-boot-supervising-route-controller) | Management and Monitoring | An example showing how to work with Camel's Supervising Route Controller and Spring Boot
 
@@ -115,7 +115,7 @@ operations on a database
 | link:camel-example-spring-boot-widget-gadget/readme.md[Spring Boot Widget Gadget] (camel-example-spring-boot-widget-gadget) | Messaging | The widget and gadget example from EIP book, running on Spring Boot
 
 | link:camel-example-spring-boot-reactive-streams/readme.adoc[Spring Boot Reactive Streams] (camel-example-spring-boot-reactive-streams) | Reactive | An example that shows how Camel can exchange data using reactive streams with Spring Boot reactor
-
+    
 
 | link:camel-example-spring-boot-geocoder/README.adoc[Spring Boot Geocoder] (camel-example-spring-boot-geocoder) | Rest | An example showing the Camel Geocoder component via REST DSL with Spring Boot
 

--- a/camel-example-spring-boot-actuator-http-metrics/pom.xml
+++ b/camel-example-spring-boot-actuator-http-metrics/pom.xml
@@ -32,7 +32,7 @@
     <description>Example on how to use Spring Boot's Actuator endpoints to gather info like mappings or metrics</description>
 
     <properties>
-        <category>Beginner</category>
+        <category>Management and Monitoring</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring.boot-version>${spring-boot-version}</spring.boot-version>

--- a/camel-example-spring-boot-actuator-http-metrics/pom.xml
+++ b/camel-example-spring-boot-actuator-http-metrics/pom.xml
@@ -75,12 +75,12 @@
             <artifactId>camel-spring-boot-starter</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-http</artifactId>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-http-starter</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-jackson</artifactId>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-jackson-starter</artifactId>
         </dependency>
     </dependencies>
 

--- a/camel-example-spring-boot-actuator-http-metrics/pom.xml
+++ b/camel-example-spring-boot-actuator-http-metrics/pom.xml
@@ -29,8 +29,10 @@
 
     <artifactId>camel-example-spring-boot-actuator-http-metrics</artifactId>
     <name>Camel SB Examples :: Actuator HTTP Metrics</name>
+    <description>Example on how to use Spring Boot's Actuator endpoints to gather info like mappings or metrics</description>
 
     <properties>
+        <category>Beginner</category>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <spring.boot-version>${spring-boot-version}</spring.boot-version>

--- a/camel-example-spring-boot-actuator-http-metrics/pom.xml
+++ b/camel-example-spring-boot-actuator-http-metrics/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.apache.camel.springboot.example</groupId>
+        <artifactId>examples</artifactId>
+        <version>3.6.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>camel-example-spring-boot-actuator-http-metrics</artifactId>
+    <name>Camel SB Examples :: Actuator HTTP Metrics</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <spring.boot-version>${spring-boot-version}</spring.boot-version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spring Boot BOM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Camel BOM -->
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-dependencies</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <!-- Camel -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-jackson</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/camel-example-spring-boot-actuator-http-metrics/readme.adoc
+++ b/camel-example-spring-boot-actuator-http-metrics/readme.adoc
@@ -1,0 +1,44 @@
+== Camel with Actuator - Mappings, Metrics and Shutdown example
+
+This example shows how you can query some of Spring Boot Actuator options from your
+Camel routes.
+
+=== How to run
+
+[source,console]
+----
+mvn compile spring-boot:run
+----
+
+=== Actuator routes
+
+You need to enable the HTTP routes on Actuator to be able to use them. For example,
+in this example we have to expose the metrics, mappings and shutdown routes.
+
+[source, properties]
+----
+management.endpoints.web.exposure.include=mappings,metrics,shutdown
+----
+
+You can see other functionalities and more details in
+https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-endpoints-enabling-endpoints[Actuator's documentation].
+
+=== Shutdown
+
+Shutdown should be handled with care for security reasons. You will need to explicitly enable
+that endpoint for it to be usable.
+
+[source, properties]
+----
+management.endpoint.shutdown.enabled=true
+----
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/support.html[let us know].
+
+We also love contributors, so
+https://camel.apache.org/contributing.html[get involved] :-)
+
+The Camel riders!

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/Application.java
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/Application.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+//CHECKSTYLE:OFF
+
+/**
+ * A sample Spring Boot application that starts the Camel routes.
+ */
+@SpringBootApplication
+public class Application {
+
+    /**
+     * A main method to start this application.
+     */
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}
+//CHECKSTYLE:ON

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
@@ -17,9 +17,7 @@
 package sample.camel;
 
 import org.apache.camel.builder.RouteBuilder;
-import org.apache.camel.model.RouteDefinition;
 import org.apache.camel.model.rest.RestBindingMode;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
@@ -36,7 +36,7 @@ public class MyRouteBuilder extends RouteBuilder {
                 .bindingMode(RestBindingMode.json);
 
         // First, let's show the routes we have exposed.
-        doOnce()
+        from("timer:queryTimer?repeatCount=1")
                 .to("rest:get:/actuator/mappings")
                 .unmarshal()
                 .json()
@@ -53,9 +53,5 @@ public class MyRouteBuilder extends RouteBuilder {
         from("timer:shutdownTimer?delay={{shutdownTime}}&repeatCount=1")
                 .log("Shutting down")
                 .to("rest:post:/actuator/shutdown");
-    }
-
-    private RouteDefinition doOnce() {
-        return from("timer:queryTimer?repeatCount=1");
     }
 }

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.model.rest.RestBindingMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MyRouteBuilder extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        // First, we have to configure our jetty component, which will be the product
+        // in charge of querying the REST endpoints from actuator
+        restConfiguration().component("jetty")
+                .host("0.0.0.0")
+                .port(8080)
+                .bindingMode(RestBindingMode.json);
+
+        // We will first show the routes we have exposed.
+        from("timer:queryTimer?repeatCount=1")
+                .to("rest:get:/actuator/mappings")
+                .unmarshal()
+                .json()
+                .to("log:INFO");
+
+        // Then, we will be querying the cpu consumption periodically. For more options, you can check
+        // https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-metrics-endpoint
+        from("timer:metricsTimer?period={{metricsPeriod}}")
+                .to("rest:get:/actuator/metrics/system.cpu.usage")
+                .unmarshal().json()
+                .to("log:INFO");
+
+        // Left to oversee how to stop routes
+    }
+}

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
@@ -53,8 +53,6 @@ public class MyRouteBuilder extends RouteBuilder {
         from("timer:shutdownTimer?delay={{shutdownTime}}&repeatCount=1")
                 .log("Shutting down")
                 .to("rest:post:/actuator/shutdown");
-
-
     }
 
     private RouteDefinition doOnce() {

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
@@ -28,7 +28,7 @@ public class MyRouteBuilder extends RouteBuilder {
 
         // First, we have to configure our jetty component, which will be the rest
         // in charge of querying the REST endpoints from actuator
-        restConfiguration().component("jetty")
+        restConfiguration()
                 .host("0.0.0.0")
                 .port(8080)
                 .bindingMode(RestBindingMode.json);

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
@@ -35,7 +35,8 @@ public class MyRouteBuilder extends RouteBuilder {
                 .port(8080)
                 .bindingMode(RestBindingMode.json);
 
-        // First, let's show the routes we have exposed.
+        // First, let's show the routes we have exposed. Let's create a timer
+        // consumer that will only fire once and show us the exposed mappings
         from("timer:queryTimer?repeatCount=1")
                 .to("rest:get:/actuator/mappings")
                 .unmarshal()

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
@@ -38,16 +38,16 @@ public class MyRouteBuilder extends RouteBuilder {
         from("timer:queryTimer?repeatCount=1")
                 .to("rest:get:/actuator/mappings")
                 .unmarshal()
-                .json()
-                .to("log:INFO");
+                .json(true)
+                .to("log:INFO?multiline=true");
 
         // Then, we will be querying the cpu consumption periodically. For more options, you can check
         // https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-metrics-endpoint
         from("timer:metricsTimer?period={{metricsPeriod}}")
                 .to("rest:get:/actuator/metrics/system.cpu.usage")
                 .unmarshal()
-                .json()
-                .to("log:INFO");
+                .json(true)
+                .to("log:INFO?multiline=true");
 
         // Finally, let's see how to shutdown our application using the actuator endpoint
         from("timer:shutdownTimer?delay={{shutdownTime}}&repeatCount=1")

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/java/sample/camel/MyRouteBuilder.java
@@ -46,7 +46,8 @@ public class MyRouteBuilder extends RouteBuilder {
         // https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-metrics-endpoint
         from("timer:metricsTimer?period={{metricsPeriod}}")
                 .to("rest:get:/actuator/metrics/system.cpu.usage")
-                .unmarshal().json()
+                .unmarshal()
+                .json()
                 .to("log:INFO");
 
         // Finally, let's see how to shutdown our application using the actuator endpoint

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/resources/application.properties
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/resources/application.properties
@@ -1,0 +1,37 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+debug = false
+
+logging.level.org.springframework = INFO
+logging.level.org.apache.camel.spring.boot = INFO
+logging.level.org.apache.camel.health = DEBUG
+logging.level.org.apache.camel.impl.health = DEBUG
+logging.level.sample.camel = DEBUG
+
+# expose actuator endpoint via HTTP
+management.endpoints.web.exposure.include=mappings,metrics
+
+camel.springboot.name = MyCamel
+
+# properties used in the route
+metricsPeriod = 2s
+countdownPeriod = 1s
+countdownTime = 10
+
+# enable supervised route controller which will startup routes in safe manner
+camel.springboot.route-controller-supervise-enabled = true

--- a/camel-example-spring-boot-actuator-http-metrics/src/main/resources/application.properties
+++ b/camel-example-spring-boot-actuator-http-metrics/src/main/resources/application.properties
@@ -23,15 +23,17 @@ logging.level.org.apache.camel.health = DEBUG
 logging.level.org.apache.camel.impl.health = DEBUG
 logging.level.sample.camel = DEBUG
 
+# enable the shutdown endpoint
+management.endpoint.shutdown.enabled=true
+
 # expose actuator endpoint via HTTP
-management.endpoints.web.exposure.include=mappings,metrics
+management.endpoints.web.exposure.include=mappings,metrics,shutdown
 
 camel.springboot.name = MyCamel
 
 # properties used in the route
 metricsPeriod = 2s
-countdownPeriod = 1s
-countdownTime = 10
+shutdownTime = 10s
 
 # enable supervised route controller which will startup routes in safe manner
 camel.springboot.route-controller-supervise-enabled = true

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <modules>
         <module>camel-example-spring-boot</module>
         <module>camel-example-spring-boot-activemq</module>
+        <module>camel-example-spring-boot-actuator-http-metrics</module>
         <module>camel-example-spring-boot-amqp</module>
         <module>camel-example-spring-boot-apm-opentracing</module>
         <module>camel-example-spring-boot-arangodb</module>


### PR DESCRIPTION
This PR adds an example about using Actuator's capabilities to query info like metrics and mappings, and also shows how can we use it to shutdown our Spring application.

[CAMEL-15323](https://issues.apache.org/jira/projects/CAMEL/issues/CAMEL-15323?filter=allopenissues)