### PR TITLE
Fix the mvn args to specify active profile in README.adoc

### DIFF
--- a/camel-example-spring-boot-rest-jpa/README.adoc
+++ b/camel-example-spring-boot-rest-jpa/README.adoc
@@ -29,7 +29,7 @@ You can run this example with Maven using:
 
 [source,sh]
 ----
-$ mvn spring-boot:run -Dspring.profiles.active=dev
+$ mvn spring-boot:run -Dspring-boot.run.profiles=dev
 ----
 
 Alternatively, you can also run this example using the executable JAR:

--- a/camel-example-spring-boot-servicecall/README.adoc
+++ b/camel-example-spring-boot-servicecall/README.adoc
@@ -36,12 +36,12 @@ Using multiple shells:
  - start the service-1 service group:
 
   $ cd services
-  $ mvn spring-boot:run -Dspring.profiles.active=service-1
+  $ mvn spring-boot:run -Dspring-boot.run.profiles=service-1
 
   - start the service-2 service group:
 
   $ cd services
-  $ mvn spring-boot:run -Dspring.profiles.active=service-2
+  $ mvn spring-boot:run -Dspring-boot.run.profiles=service-2
 
   - start the consumer
 


### PR DESCRIPTION
The mvn args should be ```-Dspring-boot.run.profiles=dev```

see https://docs.spring.io/spring-boot/docs/2.3.4.RELEASE/maven-plugin/reference/html/#run-example-active-profiles