### PR TITLE
A better suggestion about the annotation usage

### DIFF
--- a/rest-jpa/src/main/java/org/apache/camel/example/spring/boot/rest/jpa/OrderService.java
+++ b/rest-jpa/src/main/java/org/apache/camel/example/spring/boot/rest/jpa/OrderService.java
@@ -19,9 +19,9 @@ package org.apache.camel.example.spring.boot.rest.jpa;
 import java.util.Random;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Serivce;
 
-@Component
+@Serivce
 public class OrderService {
 
     private final BookRepository books;


### PR DESCRIPTION
Hi, I found that there may be some minor improvements about annotations in your code.

A Spring bean in the service layer should be annotated using @service instead of @component annotation.
@service annotation is a specialization of @component in service layer. By using a specialized annotation we hit two birds with one stone. First, they are treated as Spring bean, and second, you can put special behavior required by that layer.

For better understanding and maintainability of a large application, @service is a better choice.