### PR TITLE
PR for Jira CAMEL-17393

### DIFF
--- a/routes-configuration/pom.xml
+++ b/routes-configuration/pom.xml
@@ -119,6 +119,13 @@
             <artifactId>camel-test-spring-junit5</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- For debugging -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-debug-starter</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/routes-configuration/src/main/resources/application.yaml
+++ b/routes-configuration/src/main/resources/application.yaml
@@ -29,4 +29,4 @@ camel:
     dump-routes: true
 
     # which directory(s) to scan for routes/route-configurations which can be xml, yaml or java files
-    routes-include-pattern: classpath:myroutes/*,classpath:myerror/*
+    routes-include-pattern: classpath:myroutes/*,classpath:myerror/*,classpath:myinterceptor/*

--- a/routes-configuration/src/main/resources/myinterceptor/xml-interceptor.xml
+++ b/routes-configuration/src/main/resources/myinterceptor/xml-interceptor.xml
@@ -18,10 +18,8 @@
 
 -->
 
-<routeConfiguration id="xmlError">
-    <onException>
-        <exception>java.lang.Exception</exception>
-        <handled><constant>true</constant></handled>
-        <log message="XML WARN: ${exception.message}" id="inOnException"/>
-    </onException>
+<routeConfiguration id="xmlInterceptor">
+    <interceptFrom uri="*">
+        <log message="Message intercepted" id="inXmlInterceptor"/>
+    </interceptFrom>
 </routeConfiguration>

--- a/routes-configuration/src/main/resources/myroutes/my-xml-route.xml
+++ b/routes-configuration/src/main/resources/myroutes/my-xml-route.xml
@@ -24,7 +24,7 @@
 -->
 
 <!-- refer to the route configuration by the id to use for this route -->
-<route routeConfigurationId="xmlError">
+<route routeConfigurationId="xmlError,xmlInterceptor">
     <from uri="timer:xml?period=5s"/>
     <log message="I am XML"/>
     <throwException exceptionType="java.lang.Exception" message="Some kind of XML error"/>


### PR DESCRIPTION
It illustrates the problem reported in the Jira. The route locations bump produces the following XML:

```
<routeLocations>
    <routeLocation routeId="route1" id="route1" index="0" sourceLocation="" sourceLineNumber="-1"/>
    <routeLocation routeId="route1" id="log1" index="1" sourceLocation="" sourceLineNumber="-1"/>
    <routeLocation routeId="route1" id="setBody1" index="7" sourceLocation="" sourceLineNumber="-1"/>
    <routeLocation routeId="route1" id="log2" index="8" sourceLocation="" sourceLineNumber="-1"/>
    <routeLocation routeId="route1" id="filter1" index="9" sourceLocation="" sourceLineNumber="-1"/>
    <routeLocation routeId="route1" id="throwException1" index="10" sourceLocation="" sourceLineNumber="-1"/>
    <routeLocation routeId="route2" id="route2" index="0" sourceLocation="file:/Users/eberman/Dev/git/camel-spring-boot-examples/routes-configuration/target/classes/myroutes/my-xml-route.xml" sourceLineNumber="28"/>
    <routeLocation routeId="route2" id="inOnException" index="3" sourceLocation="file:/Users/eberman/Dev/git/camel-spring-boot-examples/routes-configuration/target/classes/myroutes/my-xml-route.xml" sourceLineNumber="25"/>
    <routeLocation routeId="route2" id="inXmlInterceptor" index="5" sourceLocation="file:/Users/eberman/Dev/git/camel-spring-boot-examples/routes-configuration/target/classes/myroutes/my-xml-route.xml" sourceLineNumber="23"/>
    <routeLocation routeId="route2" id="log3" index="12" sourceLocation="file:/Users/eberman/Dev/git/camel-spring-boot-examples/routes-configuration/target/classes/myroutes/my-xml-route.xml" sourceLineNumber="29"/>
    <routeLocation routeId="route2" id="throwException2" index="13" sourceLocation="file:/Users/eberman/Dev/git/camel-spring-boot-examples/routes-configuration/target/classes/myroutes/my-xml-route.xml" sourceLineNumber="30"/>
</routeLocations>
```
Note the IDs `inXmlInterceptor` and `inOnExceptions` - their line numbers are correct but the source locations are not.