### PR TITLE
Refactoring FHIR example

### DIFF
--- a/fhir/readme.adoc
+++ b/fhir/readme.adoc
@@ -26,7 +26,13 @@ $ mvn package
 
 == Run
 
-You can run this example using:
+Before running your application execute this command to deploy FHIR server:
+
+```
+docker run -p 8081:8080 -e HAPI_FHIR_VERSION=DSTU3 -e HAPI_REUSE_CACHED_SEARCH_RESULTS_MILLIS=-1 hapiproject/hapi:v4.2.0
+```
+
+Then you can run this example using:
 
 ```sh
 $ mvn spring-boot:run

--- a/fhir/src/main/java/sample/camel/MyCamelApplication.java
+++ b/fhir/src/main/java/sample/camel/MyCamelApplication.java
@@ -16,22 +16,8 @@
  */
 package sample.camel;
 
-import java.util.function.Consumer;
-
-import com.github.dockerjava.api.command.CreateContainerCmd;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
-
-import org.apache.camel.CamelContext;
-import org.apache.camel.spring.boot.CamelContextConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.Bean;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 
 //CHECKSTYLE:OFF
 /**
@@ -39,50 +25,11 @@ import org.testcontainers.containers.wait.strategy.Wait;
  */
 @SpringBootApplication
 public class MyCamelApplication {
-    
-    private static final Logger LOG = LoggerFactory.getLogger(MyCamelApplication.class);
-    private static final int CONTAINER_PORT = 8080;
-    private static final String CONTAINER_IMAGE = "hapiproject/hapi:v4.2.0";
-
-    private GenericContainer container;
     /**
      * A main method to start this application.
      */
     public static void main(String[] args) {
         SpringApplication.run(MyCamelApplication.class, args);
     }
-    
-    @Bean
-    CamelContextConfiguration contextConfiguration() {
-        return new CamelContextConfiguration() {
-            @Override
-            public void beforeApplicationStart(CamelContext context) {
-                LOG.info("start hapi-fhir-jpaserver-starter docker container");
-                Consumer<CreateContainerCmd> cmd = e -> {
-                    e.withPortBindings(new PortBinding(Ports.Binding.bindPort(CONTAINER_PORT),
-                    new ExposedPort(CONTAINER_PORT)));
-                    
-                };
-                
-
-                container = new GenericContainer(CONTAINER_IMAGE)
-                    .withNetworkAliases("fhir")
-                    .withExposedPorts(CONTAINER_PORT)
-                    .withCreateContainerCmdModifier(cmd)
-                    .withEnv("HAPI_FHIR_VERSION", "DSTU3")
-                    .withEnv("HAPI_REUSE_CACHED_SEARCH_RESULTS_MILLIS", "-1")
-                    .waitingFor(Wait.forListeningPort())
-                    .waitingFor(Wait.forHttp("/hapi-fhir-jpaserver/fhir/metadata"));;
-                container.start();
-                
-            }
-
-            @Override
-            public void afterApplicationStart(CamelContext camelContext) {
-                // noop
-            }
-        };
-    }
-
 
 }

--- a/fhir/src/main/resources/application.properties
+++ b/fhir/src/main/resources/application.properties
@@ -15,7 +15,7 @@
 ## limitations under the License.
 ## ---------------------------------------------------------------------------
 
-serverUrl=http://localhost:8080/hapi-fhir-jpaserver/fhir
+serverUrl=http://localhost:8081/hapi-fhir-jpaserver/fhir
 
 fhirVersion=DSTU3
 
@@ -23,8 +23,6 @@ input=target/work/fhir/input
 
 # the name of Camel
 camel.springboot.name = MyCamel
-
-server.port=0
 
 # to automatic shutdown the JVM after a period of time
 #camel.springboot.duration-max-seconds=60

--- a/fhir/src/test/java/sample/camel/MyCamelApplicationTest.java
+++ b/fhir/src/test/java/sample/camel/MyCamelApplicationTest.java
@@ -16,34 +16,77 @@
  */
 package sample.camel;
 
-import java.io.File;
-
 import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
 import org.apache.camel.component.mock.MockEndpoint;
 import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
-import org.apache.camel.test.spring.junit5.MockEndpointsAndSkip;
 import org.apache.commons.io.FileUtils;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import org.hl7.fhir.dstu3.model.Patient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 @CamelSpringBootTest
 @SpringBootTest(classes = MyCamelApplication.class,
-    properties = "input = target/work/fhir/testinput")
-@MockEndpointsAndSkip("fhir*")
+		properties = "input = target/work/fhir/testinput")
 public class MyCamelApplicationTest {
 
-    @Autowired
-    private CamelContext camelContext;
+	private static final int CONTAINER_PORT = 8080;
+	private static final int EXPOSED_PORT = 8081;
+	private static final String CONTAINER_IMAGE = "hapiproject/hapi:v4.2.0";
 
-    @Test
-    public void shouldPushConvertedHl7toFhir() throws Exception {
-        MockEndpoint mock = camelContext.getEndpoint("mock:fhir:create/resource", MockEndpoint.class);
-        mock.expectedBodiesReceived("{\"resourceType\":\"Patient\",\"id\":\"100005056\",\"name\":[{\"family\":\"Freeman\",\"given\":[\"Vincent\"]}]}");
+	private static GenericContainer container;
 
-        FileUtils.copyDirectory(new File("src/main/data"), new File("target/work/fhir/testinput"));
+	@Autowired
+	private CamelContext camelContext;
 
-        mock.assertIsSatisfied();
-    }
+	@Autowired
+	private ProducerTemplate producerTemplate;
 
+	@BeforeAll
+	public static void startServer() throws Exception {
+		Consumer<CreateContainerCmd> cmd = e -> {
+			e.withPortBindings(new PortBinding(Ports.Binding.bindPort(EXPOSED_PORT),
+					new ExposedPort(CONTAINER_PORT)));
+		};
+
+		container = new GenericContainer(CONTAINER_IMAGE)
+				.withNetworkAliases("fhir")
+				.withExposedPorts(CONTAINER_PORT)
+				.withCreateContainerCmdModifier(cmd)
+				.withEnv("HAPI_FHIR_VERSION", "DSTU3")
+				.withEnv("HAPI_REUSE_CACHED_SEARCH_RESULTS_MILLIS", "-1")
+				.waitingFor(Wait.forListeningPort())
+				.waitingFor(Wait.forHttp("/hapi-fhir-jpaserver/fhir/metadata"));
+		;
+		container.start();
+	}
+
+	@Test
+	public void shouldPushConvertedHl7toFhir() throws Exception {
+		MockEndpoint mock = camelContext.getEndpoint("mock:result", MockEndpoint.class);
+		mock.expectedMessageCount(1);
+
+		FileUtils.copyDirectory(new File("src/main/data"), new File("target/work/fhir/testinput"));
+		Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+		producerTemplate.sendBody("direct:start", null);
+
+		mock.assertIsSatisfied();
+		Assertions.assertEquals("Freeman", mock.getExchanges().get(0).getIn().getBody(Patient.class).getName().get(0).getFamily());
+	}
 }

--- a/fhir/src/test/java/sample/camel/MyCamelTestRouter.java
+++ b/fhir/src/test/java/sample/camel/MyCamelTestRouter.java
@@ -1,0 +1,16 @@
+package sample.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MyCamelTestRouter extends RouteBuilder {
+
+	@Override
+	public void configure() throws Exception {
+		from("direct:start")
+				.to("fhir://read/resourceById?resourceClass=Patient&stringId=1&serverUrl={{serverUrl}}&fhirVersion={{fhirVersion}}")
+				.to("mock:result");
+	}
+}


### PR DESCRIPTION
Starting FHIR container as part of the example's source code is not the best practice. So I moved it to readme and user need to start it manually as one of the requirements.
I moved container usage to test and removed mocked fhir.
Then I changed FHIR server port to 8081 because **http://localhost:8080/actuator/health** is not accessible.