### PR TITLE
Prevent CI workflows from running on forks

### DIFF
--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -23,6 +23,7 @@ on:
       - main
 jobs:
   build:
+    if: github.repository == 'apache/camel-spring-boot-examples'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -23,6 +23,7 @@ on:
       - main
 jobs:
   build:
+    if: github.repository == 'apache/camel-spring-boot-examples'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Prevent camel-spring-boot-examples workflows from running on forks like camel-quarkus does https://github.com/apache/camel-quarkus/commit/a4174460f67bfb792d331512abbab928c7d71dd5