### PR TITLE
Use camel-observation-starter version from the BOM

### DIFF
--- a/observation/service1/pom.xml
+++ b/observation/service1/pom.xml
@@ -84,7 +84,6 @@
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
             <artifactId>camel-observation-starter</artifactId>
-            <version>${camel-version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>


### PR DESCRIPTION
Shouldn't be using camel-version for a camel-spring-boot starter