### PR TITLE
CAMEL-19510: reactive-streams - Fix the simple expression

### DIFF
--- a/reactive-streams/src/main/java/org/apache/camel/example/reactive/streams/RestExample.java
+++ b/reactive-streams/src/main/java/org/apache/camel/example/reactive/streams/RestExample.java
@@ -70,8 +70,8 @@ public class RestExample {
                     .to("direct:sum");
 
             from("direct:sum")
-                    .setHeader("num1").simple("headerAs(num1,Long)")
-                    .setHeader("num2").simple("headerAs(num2,Long)")
+                    .setHeader("num1").simple("${headerAs(num1,Long)}")
+                    .setHeader("num2").simple("${headerAs(num2,Long)}")
                     .bean("calculator", "sum")
                     .process(new UnwrapStreamProcessor())
                     .setBody().simple("The result is: ${body}");


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-19510

## Motivation

The rest endpoint defined in RestExample fails with an error of type `java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Long`

## Modifications:

* Fixes the simple expression