### PR TITLE
CAMEL-19510: reactive-streams - Fix the auto configuration

### DIFF
--- a/amqp/src/main/java/sample/camel/SampleAmqApplication.java
+++ b/amqp/src/main/java/sample/camel/SampleAmqApplication.java
@@ -17,12 +17,10 @@
 package sample.camel;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 //CHECKSTYLE:OFF
 @SpringBootApplication
-@EnableAutoConfiguration
 public class SampleAmqApplication {
 
     public static void main(String[] args) {

--- a/artemis/src/main/java/sample/camel/SampleAmqApplication.java
+++ b/artemis/src/main/java/sample/camel/SampleAmqApplication.java
@@ -17,12 +17,10 @@
 package sample.camel;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 //CHECKSTYLE:OFF
 @SpringBootApplication
-@EnableAutoConfiguration
 public class SampleAmqApplication {
     public static void main(String[] args) {
         SpringApplication.run(SampleAmqApplication.class, args);

--- a/reactive-streams/src/main/java/org/apache/camel/example/reactive/streams/RestExample.java
+++ b/reactive-streams/src/main/java/org/apache/camel/example/reactive/streams/RestExample.java
@@ -70,8 +70,8 @@ public class RestExample {
                     .to("direct:sum");
 
             from("direct:sum")
-                    .setHeader("num1").simple("headerAs(num1,Long)")
-                    .setHeader("num2").simple("headerAs(num2,Long)")
+                    .setHeader("num1").simple("${headerAs(num1,Long)}")
+                    .setHeader("num2").simple("${headerAs(num2,Long)}")
                     .bean("calculator", "sum")
                     .process(new UnwrapStreamProcessor())
                     .setBody().simple("The result is: ${body}");

--- a/reactive-streams/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/reactive-streams/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -31,12 +31,11 @@
 # limitations under the License.
 #
 
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.apache.camel.example.reactive.streams.BasicCamelToReactorExample,\
-org.apache.camel.example.reactive.streams.BasicReactorToCamelExample,\
-org.apache.camel.example.reactive.streams.BasicReactorToCamelInOutExample,\
-org.apache.camel.example.reactive.streams.BasicCamelToReactorInOutExample,\
-org.apache.camel.example.reactive.streams.RestExample,\
-org.apache.camel.example.reactive.streams.ClientAPIRestExample,\
+org.apache.camel.example.reactive.streams.BasicCamelToReactorExample
+org.apache.camel.example.reactive.streams.BasicReactorToCamelExample
+org.apache.camel.example.reactive.streams.BasicReactorToCamelInOutExample
+org.apache.camel.example.reactive.streams.BasicCamelToReactorInOutExample
+org.apache.camel.example.reactive.streams.RestExample
+org.apache.camel.example.reactive.streams.ClientAPIRestExample
 org.apache.camel.example.reactive.streams.ClientAPIWorkflowExample
 


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-19510

## Motivation

No routes are even started

## Modifications

* Fixes the simple expression
* The way [to register auto-configurations has changed](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files), the code must be changed consequently
* Removes unnecessary annotation `EnableAutoConfiguration` as it is already included `SpringBootApplication`