### PR TITLE
Adding camel-activemq using openwire example.

### DIFF
--- a/activemq/pom.xml
+++ b/activemq/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+      <groupId>org.apache.camel.springboot.example</groupId>
+      <artifactId>examples</artifactId>
+      <version>4.4.0-SNAPSHOT</version>
+    </parent>
+    
+    <artifactId>camel-example-spring-boot-activemq</artifactId>
+    <name>Camel SB Examples :: ActiveMQ</name>
+    <description>An example showing how to work with Camel, ActiveMQ openwire and Spring Boot</description>
+    
+    <properties>
+        <category>Messaging</category>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <activemq-version>5.18.3</activemq-version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Spring Boot BOM -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- Camel BOM -->
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- Spring Boot -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <!-- Camel -->
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel.springboot</groupId>
+            <artifactId>camel-activemq-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.messaginghub</groupId>
+            <artifactId>pooled-jms</artifactId>
+            <version>3.1.5</version>
+        </dependency>
+
+        <!-- test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-test-spring-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/activemq/pom.xml
+++ b/activemq/pom.xml
@@ -82,7 +82,6 @@
         <dependency>
             <groupId>org.messaginghub</groupId>
             <artifactId>pooled-jms</artifactId>
-            <version>3.1.5</version>
         </dependency>
 
         <!-- test -->

--- a/activemq/readme.adoc
+++ b/activemq/readme.adoc
@@ -1,0 +1,38 @@
+== Camel Example Spring Boot and ActiveMQ
+
+This example shows how to work with a simple Apache Camel application using Spring Boot and Apache ActiveMQ.
+In contrast to the amqp example in this repo, it uses ActiveMQs openwire protocol and the 
+camel-activemq component.
+
+=== Preparing ActiveMQ brokers
+
+From Apache ActiveMQ you can download the broker as a `.zip` or `.tar.gz` file.
+
+Unzip/tar the archive, and start a terminal.
+
+Change directory to the unzipped directory and start the broker.
+
+    bin/activemq console
+
+Which runs the broker in the foreground and logs to the console.
+
+=== How to run the example
+
+You can run this example using
+
+    mvn spring-boot:run
+
+=== Using Camel components
+
+Apache Camel provides 200+ components which you can use to integrate and route messages between many systems
+and data formats. To use any of these Camel components, add the component as a dependency to your project.
+
+=== Help and contributions
+
+If you hit any problem using Camel or have some feedback, then please
+https://camel.apache.org/support.html[let us know].
+
+We also love contributors, so
+https://camel.apache.org/contributing.html[get involved] :-)
+
+The Camel riders!

--- a/activemq/src/main/java/sample/camel/SampleAmqApplication.java
+++ b/activemq/src/main/java/sample/camel/SampleAmqApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration;
+
+/* Disable ActiveMQAutoConfiguration to prevent Spring Boot from creating a
+   default ConnectionFactory.  This allows us to configure our own ConnectionFactory
+   via camel.component.activemq properties in application.properties.
+*/
+@SpringBootApplication
+@EnableAutoConfiguration(exclude = {ActiveMQAutoConfiguration.class})
+public class SampleAmqApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(SampleAmqApplication.class, args);
+    }
+}

--- a/activemq/src/main/java/sample/camel/SampleAutowiredActiveMQRoute.java
+++ b/activemq/src/main/java/sample/camel/SampleAutowiredActiveMQRoute.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import org.apache.camel.builder.RouteBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SampleAutowiredActiveMQRoute extends RouteBuilder {
+
+    @Override
+    public void configure() throws Exception {
+
+        from("timer:bar")
+            .id("producer-route")
+            .setBody(constant("Hello from Camel"))
+            .to("activemq:queue:SCIENCEQUEUE")
+            .log("Message sent from route ${routeId}.");
+
+	    from("activemq:queue:SCIENCEQUEUE")
+	        .id("consumer-route")
+	        .to("log:MyLogger?showBody=true");
+    }
+}

--- a/activemq/src/main/resources/application.properties
+++ b/activemq/src/main/resources/application.properties
@@ -1,0 +1,40 @@
+## ---------------------------------------------------------------------------
+## Licensed to the Apache Software Foundation (ASF) under one or more
+## contributor license agreements.  See the NOTICE file distributed with
+## this work for additional information regarding copyright ownership.
+## The ASF licenses this file to You under the Apache License, Version 2.0
+## (the "License"); you may not use this file except in compliance with
+## the License.  You may obtain a copy of the License at
+##
+##      http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+## ---------------------------------------------------------------------------
+
+camel.springboot.main-run-controller = true
+
+# This configures Springs default ActiveMQConnectionFactory that is 
+# created by Spring Boot AutoConfiguration unless ActiveMQAutoConfiguration
+# is explicitly disabled (which it is in this example).
+# spring.activemq.broker-url=tcp://localhost:61616
+# spring.activemq.user=admin
+# spring.activemq.password=admin
+# spring.activemq.pool.enabled=false
+# spring.activemq.pool.max-connections=1
+
+# camel-activemq config
+camel.component.activemq.broker-url=tcp://localhost:61616
+camel.component.activemq.username=admin
+camel.component.activemq.password=admin
+camel.component.activemq.use-pooled-connection=true
+camel.component.activemq.use-single-connection=false
+camel.component.activemq.cache-level-name=CACHE_CONSUMER
+camel.component.activemq.transacted=true
+
+# Logging configuration, useful to see transactions in action
+# logging.level.org.apache.camel.component.jms=DEBUG
+# logging.level.org.springframework.jms.connection.JmsTransactionManager=DEBUG

--- a/activemq/src/test/java/sample/camel/SampleAmqApplicationTests.java
+++ b/activemq/src/test/java/sample/camel/SampleAmqApplicationTests.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package sample.camel;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.NotifyBuilder;
+import org.apache.camel.test.spring.junit5.CamelSpringBootTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@CamelSpringBootTest
+@SpringBootTest(classes = SampleAmqApplication.class)
+public class SampleAmqApplicationTests {
+    @Autowired
+    private CamelContext camelContext;
+
+    @Disabled("Requires a running ActiveMQ broker.")
+    @Test
+    public void shouldProduceMessages() throws Exception {
+        NotifyBuilder notify = new NotifyBuilder(camelContext).whenDone(1).create();
+
+        assertTrue(notify.matches(10, TimeUnit.SECONDS));
+    }
+}


### PR DESCRIPTION
Adding camel-activemq using openwire example. Excludes Spring Boot's ActiveMQAutoConfiguration in order to configure camel-activemq entirely using 'camel.component.activemq' configuration and not via 'spring.activemq' configuration.

Another implication is that the example uses 'org.messaginghub:pooled-jms' instead of Spring's auto configuration, which wraps the ActiveMQConnectionFactory inside Springs CachingConnectionFactory.