### PR TITLE
Play tests on GitHub CI

### DIFF
--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -36,3 +36,5 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: mvn build
         run: ./mvnw -f pom.xml -V --no-transfer-progress clean install -DskipTests
+      - name: mvn test
+        run: ./mvnw -f pom.xml -V --no-transfer-progress test

--- a/.github/workflows/master-push-build.yml
+++ b/.github/workflows/master-push-build.yml
@@ -36,3 +36,5 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: mvn build
         run: ./mvnw -f pom.xml -V --no-transfer-progress clean install -DskipTests
+      - name: mvn test
+        run: ./mvnw -f pom.xml -V --no-transfer-progress test


### PR DESCRIPTION
do not merge right away as there are currently tests failing, for instance:

```
[ERROR] Failures: 
[ERROR] sample.camel.MyCamelApplicationTest.shouldPushConvertedHl7toFhir
[ERROR]   Run 1: MyCamelApplicationTest.shouldPushConvertedHl7toFhir:46 mock://fhir:transaction/withResources Received message count. Expected: <1> but was: <0>
[ERROR]   Run 2: MyCamelApplicationTest.shouldPushConvertedHl7toFhir:46 mock://fhir:transaction/withResources Received message count. Expected: <1> but was: <0>
[ERROR]   Run 3: MyCamelApplicationTest.shouldPushConvertedHl7toFhir:46 mock://fhir:transaction/withResources Received message count. Expected: <1> but was: <0>
```
