### PR TITLE
Change artifactId of tomcat-jdbc example so it doesn't collide with spring-boot example

### DIFF
--- a/tomcat-jdbc/pom.xml
+++ b/tomcat-jdbc/pom.xml
@@ -27,7 +27,7 @@
         <version>4.9.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>camel-example-spring-boot</artifactId>
+    <artifactId>camel-example-tomcat-jdbc</artifactId>
     <name>Camel SB Examples :: Tomcat JDBC</name>
     <description>An example showing how to deploy a Camel Spring Boot application in Tomcat using its JDBC Data Source</description>
     <packaging>war</packaging>


### PR DESCRIPTION
camel-spring-boot-examples is not building for me because https://github.com/apache/camel-spring-boot-examples/blob/main/spring-boot/pom.xml#L30 collides with https://github.com/apache/camel-spring-boot-examples/blob/main/tomcat-jdbc/pom.xml#L30 (likely due to copy-paste).    Change the artifactId of tomcat-jdbc to match tomcat-jdbc.