### PR TITLE
Use camel version of commons-io (commons-io-version).   

### DIFF
--- a/fhir-auth-tx/pom.xml
+++ b/fhir-auth-tx/pom.xml
@@ -60,7 +60,7 @@
             <dependency>
             	<groupId>commons-io</groupId>
             	<artifactId>commons-io</artifactId>
-            	<version>2.16.1</version>
+            	<version>${commons-io-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Unit tests are failing in the PR test build because of API differences between 2.16.1 and 2.17.0