### PR TITLE
CAMEL-21350: Updates/Removes old dependencies

### DIFF
--- a/kafka-avro/pom.xml
+++ b/kafka-avro/pom.xml
@@ -62,6 +62,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <!-- manages conflict forcing CSB/Camel version -->
+            <dependency>
+                <groupId>org.apache.avro</groupId>
+                <artifactId>avro</artifactId>
+                <version>${avro-version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/kafka-avro/src/main/java/org/apache/camel/example/kafka/avro/CustomKafkaAvroDeserializer.java
+++ b/kafka-avro/src/main/java/org/apache/camel/example/kafka/avro/CustomKafkaAvroDeserializer.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import io.confluent.common.config.ConfigException;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
@@ -37,16 +36,10 @@ public class CustomKafkaAvroDeserializer extends AbstractKafkaAvroDeserializer  
         LOG.info("ENTER CustomKafkaAvroDeserializer  : configure method ");
         LOG.info("ENTER CustomKafkaAvroDeserializer  : SCHEMA_REGISTRY_URL " + SCHEMA_REGISTRY_URL);
 
-        try {
+        final List<String> schemas = Collections.singletonList(SCHEMA_REGISTRY_URL);
+        this.schemaRegistry = new CachedSchemaRegistryClient(schemas, Integer.MAX_VALUE);
+        this.useSpecificAvroReader = true;
 
-            final List<String> schemas = Collections.singletonList(SCHEMA_REGISTRY_URL);
-            this.schemaRegistry = new CachedSchemaRegistryClient(schemas, Integer.MAX_VALUE);
-            this.useSpecificAvroReader = true;
-
-        } catch (ConfigException e) {
-            e.printStackTrace();
-            throw new org.apache.kafka.common.config.ConfigException(e.getMessage());
-        }
         LOG.info("EXIT CustomKafkaAvroDeserializer  : configure method ");
 
     }

--- a/kafka-avro/src/main/java/org/apache/camel/example/kafka/avro/CustomKafkaAvroSerializer.java
+++ b/kafka-avro/src/main/java/org/apache/camel/example/kafka/avro/CustomKafkaAvroSerializer.java
@@ -20,9 +20,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaUtils;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerializer;
-import io.confluent.kafka.serializers.AvroSchemaUtils;
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.serialization.Serializer;
@@ -46,8 +47,9 @@ public class CustomKafkaAvroSerializer extends AbstractKafkaAvroSerializer  impl
         LOG.info("****************serialize*******************************");
         LOG.info("Serialize method: topic " + topic);
         LOG.info("Serialize method: byte " + record);
+        AvroSchema schema = new AvroSchema(AvroSchemaUtils.getSchema(record));
         return serializeImpl(
-             getSubjectName(topic, isKey, record, AvroSchemaUtils.getSchema(record)), record);
+                getSubjectName(topic, isKey, record, schema), record, schema);
     }
 
     @Override

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -117,7 +117,6 @@
             <id>openshift</id>
             <properties>
                 <sbProfile>openshift</sbProfile>
-                <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-17</jkube.generator.from>
             </properties>
             <activation>
                 <property>

--- a/pom.xml
+++ b/pom.xml
@@ -100,14 +100,13 @@
 	<properties>
 		<camel-version>4.9.0-SNAPSHOT</camel-version>
 		<skip.starting.camel.context>false</skip.starting.camel.context>
-		<javax.servlet.api.version>4.0.1</javax.servlet.api.version>
-		<jkube-maven-plugin-version>1.14.0</jkube-maven-plugin-version>
-		<kafka-avro-serializer-version>5.2.2</kafka-avro-serializer-version>
-		<reactor-version>3.5.11</reactor-version>
-		<testcontainers-version>1.19.8</testcontainers-version>
-		<hapi-structures-v24-version>2.3</hapi-structures-v24-version>
-		<narayana-spring-boot-version>2.6.7</narayana-spring-boot-version>
-        <artemis-jakarta-version>2.31.0</artemis-jakarta-version>
+		<jkube-maven-plugin-version>1.17.0</jkube-maven-plugin-version>
+		<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+		<kafka-avro-serializer-version>7.1.1</kafka-avro-serializer-version>
+		<reactor-version>3.7.0</reactor-version>
+		<testcontainers-version>1.20.4</testcontainers-version>
+		<hapi-structures-v24-version>2.5.1</hapi-structures-v24-version>
+		<artemis-jakarta-version>2.38.0</artemis-jakarta-version>
 	</properties>
 
 	<repositories>
@@ -135,20 +134,6 @@
 			</releases>
 		</pluginRepository>
 	</pluginRepositories>
-
-	<dependencyManagement>
-		<dependencies>
-			<!--
-			  CAMEL-13084 Fix the spring-boot examples start up error by overriding servlet API version from camel-parent
-			  We need to clean it up once camel-parent upgrade the servlet api version.
-			-->
-			<dependency>
-				<groupId>javax.servlet</groupId>
-				<artifactId>javax.servlet-api</artifactId>
-				<version>${javax.servlet.api.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -37,7 +37,6 @@
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-17</jkube.generator.from>
     </properties>
 
     <modules>


### PR DESCRIPTION
- `javax.servlet.api.version` no more needed 
- `jkube-maven-plugin-version` updated to the latest GA
- `kafka-avro-serializer-version` updated to the latest GA (closest version to org.apache.avro:avro:1.12.0 provided as transitive dependency of org.apache.camel:camel-avro)
- `reactor-version` aligned with Camel
- `testcontainers-version` aligned with Camel
- `hapi-structures-v24-version` aligned with Camel
- `narayana-spring-boot-version `no more needed
- `artemis-jakarta-version` aligned with Camel