### PR TITLE
Upgrade examples to 4.11.0-SNAPSHOT

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 61 (0 deprecated)
+Number of Examples: 62 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===
@@ -98,7 +98,7 @@ Number of Examples: 61 (0 deprecated)
 | link:fhir/readme.adoc[Fhir] (fhir) | Health Care | An example showing how to work with Camel, FHIR and Spring Boot
 
 | link:fhir-auth-tx/readme.adoc[Fhir Auth Tx] (fhir-auth-tx) | Health Care | An example showing how to work with Camel, FHIR Authorization, FHIR Transaction and Spring Boot
-
+    
 
 | link:validator/readme.adoc[Validator Spring Boot] (validator) | Input/Output Type Contract | An example showing how to work with declarative validation and Spring Boot
 
@@ -114,7 +114,7 @@ Number of Examples: 61 (0 deprecated)
 | link:metrics/README.adoc[Metrics] (metrics) | Management and Monitoring | An example showing how to work with Camel and Spring Boot and report metrics to Graphite
 
 | link:observation/README.adoc[Micrometer Observation] (observation) | Management and Monitoring | An example showing how to trace incoming and outgoing messages from Camel with Micrometer Observation
-
+    
 
 | link:opentelemetry/README.adoc[OpenTelemetry] (opentelemetry) | Management and Monitoring | An example showing how to use Camel with OpenTelemetry
 
@@ -128,7 +128,7 @@ Number of Examples: 61 (0 deprecated)
 
 | link:kafka-avro/README.adoc[Kafka Avro] (kafka-avro) | Messaging | An example for Kafka avro
 
-| link:kafka-oauth/README.adoc[Kafka OAuth] (kafka-oauth) | Messaging | An example for Kafka authentication using OAuth
+| link:kafka-oauth/README.adoc[Kafka Oauth] (kafka-oauth) | Messaging | An example of Kafka authentication using OAuth.
 
 | link:kafka-offsetrepository/README.adoc[Kafka Offsetrepository] (kafka-offsetrepository) | Messaging | An example for Kafka offsetrepository
 
@@ -141,7 +141,7 @@ Number of Examples: 61 (0 deprecated)
 | link:widget-gadget/README.adoc[Widget Gadget] (widget-gadget) | Messaging | The widget and gadget example from EIP book, running on Spring Boot
 
 | link:reactive-streams/readme.adoc[Reactive Streams] (reactive-streams) | Reactive | An example that shows how Camel can exchange data using reactive streams with Spring Boot reactor
-
+    
 
 | link:http-ssl/README.adoc[Http Ssl] (http-ssl) | Rest | An example showing the Camel HTTP component with Spring Boot and SSL
 

--- a/activemq/pom.xml
+++ b/activemq/pom.xml
@@ -25,7 +25,7 @@
     <parent>
       <groupId>org.apache.camel.springboot.example</groupId>
       <artifactId>examples</artifactId>
-      <version>4.10.0-SNAPSHOT</version>
+      <version>4.11.0-SNAPSHOT</version>
     </parent>
     
     <artifactId>camel-example-spring-boot-activemq</artifactId>

--- a/actuator-http-metrics/pom.xml
+++ b/actuator-http-metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-actuator-http-metrics</artifactId>

--- a/amqp/pom.xml
+++ b/amqp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-amqp</artifactId>

--- a/aot-basic/pom.xml
+++ b/aot-basic/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-aot-basic</artifactId>

--- a/arangodb/pom.xml
+++ b/arangodb/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-arangodb</artifactId>

--- a/artemis/pom.xml
+++ b/artemis/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-artemis</artifactId>

--- a/aws-secrets-manager/pom.xml
+++ b/aws-secrets-manager/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-aws-secrets-manager</artifactId>

--- a/aws2-s3/pom.xml
+++ b/aws2-s3/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-aws2-s3</artifactId>

--- a/azure/camel-example-spring-boot-azure-eventhubs/pom.xml
+++ b/azure/camel-example-spring-boot-azure-eventhubs/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>camel-example-spring-boot-azure</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-spring-boot-azure-eventhubs</artifactId>

--- a/azure/camel-example-spring-boot-azure-servicebus/pom.xml
+++ b/azure/camel-example-spring-boot-azure-servicebus/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>camel-example-spring-boot-azure</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-spring-boot-azure-servicebus</artifactId>

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>examples</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-spring-boot-azure</artifactId>

--- a/dynamic-router-eip/dynamic-router-eip-single/pom.xml
+++ b/dynamic-router-eip/dynamic-router-eip-single/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>camel-example-spring-boot-dynamic-router-eip</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-spring-boot-dynamic-router-eip-single</artifactId>

--- a/dynamic-router-eip/dynamic-router-eip-stack/all-numbers-service/pom.xml
+++ b/dynamic-router-eip/dynamic-router-eip-stack/all-numbers-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>camel-example-spring-boot-dynamic-router-eip-stack</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>all-numbers-service</artifactId>

--- a/dynamic-router-eip/dynamic-router-eip-stack/even-numbers-service/pom.xml
+++ b/dynamic-router-eip/dynamic-router-eip-stack/even-numbers-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>camel-example-spring-boot-dynamic-router-eip-stack</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>even-numbers-service</artifactId>

--- a/dynamic-router-eip/dynamic-router-eip-stack/main-router/pom.xml
+++ b/dynamic-router-eip/dynamic-router-eip-stack/main-router/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>camel-example-spring-boot-dynamic-router-eip-stack</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>main-router</artifactId>

--- a/dynamic-router-eip/dynamic-router-eip-stack/numbers-common/pom.xml
+++ b/dynamic-router-eip/dynamic-router-eip-stack/numbers-common/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>camel-example-spring-boot-dynamic-router-eip-stack</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>numbers-common</artifactId>

--- a/dynamic-router-eip/dynamic-router-eip-stack/odd-numbers-service/pom.xml
+++ b/dynamic-router-eip/dynamic-router-eip-stack/odd-numbers-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>camel-example-spring-boot-dynamic-router-eip-stack</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>odd-numbers-service</artifactId>

--- a/dynamic-router-eip/dynamic-router-eip-stack/pom.xml
+++ b/dynamic-router-eip/dynamic-router-eip-stack/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.apache.camel.springboot.example</groupId>
     <artifactId>camel-example-spring-boot-dynamic-router-eip</artifactId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-spring-boot-dynamic-router-eip-stack</artifactId>

--- a/dynamic-router-eip/pom.xml
+++ b/dynamic-router-eip/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-dynamic-router-eip</artifactId>

--- a/endpointdsl/pom.xml
+++ b/endpointdsl/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-endpointdsl</artifactId>

--- a/fhir-auth-tx/pom.xml
+++ b/fhir-auth-tx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-fhir-auth-tx</artifactId>

--- a/fhir/pom.xml
+++ b/fhir/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-fhir</artifactId>

--- a/health-checks/pom.xml
+++ b/health-checks/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-health-checks</artifactId>

--- a/http-ssl/pom.xml
+++ b/http-ssl/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>examples</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-http-ssl</artifactId>

--- a/http-ssl/ssl-camel-server/pom.xml
+++ b/http-ssl/ssl-camel-server/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-http-ssl</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-http-ssl-camel-server</artifactId>

--- a/http-ssl/ssl-client/pom.xml
+++ b/http-ssl/ssl-client/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-http-ssl</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-http-ssl-client</artifactId>

--- a/http-ssl/ssl-server/pom.xml
+++ b/http-ssl/ssl-server/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-http-ssl</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-http-ssl-server</artifactId>

--- a/infinispan/pom.xml
+++ b/infinispan/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-infinispan</artifactId>

--- a/jira/pom.xml
+++ b/jira/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-jira</artifactId>

--- a/jolokia/pom.xml
+++ b/jolokia/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>examples</artifactId>
     <groupId>org.apache.camel.springboot.example</groupId>
-    <version>4.10.0-SNAPSHOT</version>
+    <version>4.11.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>camel-example-spring-boot-jolokia</artifactId>

--- a/kafka-avro/pom.xml
+++ b/kafka-avro/pom.xml
@@ -23,7 +23,7 @@
   <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
   <artifactId>camel-example-spring-boot-kafka-avro</artifactId>

--- a/kafka-oauth/pom.xml
+++ b/kafka-oauth/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-kafka-oauth</artifactId>

--- a/kafka-offsetrepository/pom.xml
+++ b/kafka-offsetrepository/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-kafka-offsetrepository</artifactId>

--- a/kamelet-chucknorris/pom.xml
+++ b/kamelet-chucknorris/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-kamelet-chucknorris</artifactId>

--- a/load-balancer-eip/pom.xml
+++ b/load-balancer-eip/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>examples</artifactId>
 		<groupId>org.apache.camel.springboot.example</groupId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/mail-ms-exchange-oauth2/pom.xml
+++ b/mail-ms-exchange-oauth2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.apache.camel.springboot.example</groupId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/master/pom.xml
+++ b/master/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-master</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-metrics</artifactId>

--- a/multi-datasource-2pc/pom.xml
+++ b/multi-datasource-2pc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-muti-datasources-2pc</artifactId>

--- a/observation/client/pom.xml
+++ b/observation/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-observation</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-observation-client</artifactId>

--- a/observation/loggingtracer/pom.xml
+++ b/observation/loggingtracer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-observation</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-observation-loggingtracer</artifactId>

--- a/observation/pom.xml
+++ b/observation/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-observation</artifactId>

--- a/observation/service1/pom.xml
+++ b/observation/service1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-observation</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-observation-service1</artifactId>

--- a/observation/service2/pom.xml
+++ b/observation/service2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-observation</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-observation-service2</artifactId>

--- a/openapi-contract-first/pom.xml
+++ b/openapi-contract-first/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-openapi-contract-first</artifactId>

--- a/opentelemetry/CarBooking/pom.xml
+++ b/opentelemetry/CarBooking/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-opentelemetry</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-opentelemetry-carbooking</artifactId>

--- a/opentelemetry/FlightBooking/pom.xml
+++ b/opentelemetry/FlightBooking/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-opentelemetry</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-opentelemetry-flightbooking</artifactId>

--- a/opentelemetry/HotelBooking/pom.xml
+++ b/opentelemetry/HotelBooking/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-opentelemetry</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-opentelemetry-hotelbooking</artifactId>

--- a/opentelemetry/TripBooking/pom.xml
+++ b/opentelemetry/TripBooking/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-opentelemetry</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-opentelemetry-tripbooking</artifactId>

--- a/opentelemetry/pom.xml
+++ b/opentelemetry/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-opentelemetry</artifactId>

--- a/paho-mqtt5-shared-subscriptions/pom.xml
+++ b/paho-mqtt5-shared-subscriptions/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.apache.camel.springboot.example</groupId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/platform-http/pom.xml
+++ b/platform-http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-platform-http</artifactId>

--- a/pojo/pom.xml
+++ b/pojo/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-pojo</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot</groupId>
 		<artifactId>spring-boot</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<groupId>org.apache.camel.springboot.example</groupId>
@@ -99,7 +99,7 @@
     </modules>
 
 	<properties>
-		<camel-version>4.10.0-SNAPSHOT</camel-version>
+		<camel-version>4.11.0-SNAPSHOT</camel-version>
 		<skip.starting.camel.context>false</skip.starting.camel.context>
 		<jkube-maven-plugin-version>1.17.0</jkube-maven-plugin-version>
 		<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>

--- a/quartz/pom.xml
+++ b/quartz/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-quartz</artifactId>

--- a/rabbitmq/pom.xml
+++ b/rabbitmq/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rabbitmq</artifactId>

--- a/reactive-streams/pom.xml
+++ b/reactive-streams/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-reactive-streams</artifactId>

--- a/resilience4j/client/pom.xml
+++ b/resilience4j/client/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-resilience4j</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-client</artifactId>

--- a/resilience4j/client2/pom.xml
+++ b/resilience4j/client2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-resilience4j</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-client2</artifactId>

--- a/resilience4j/pom.xml
+++ b/resilience4j/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j</artifactId>

--- a/resilience4j/service1/pom.xml
+++ b/resilience4j/service1/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-resilience4j</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-service1</artifactId>

--- a/resilience4j/service2/pom.xml
+++ b/resilience4j/service2/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>camel-example-spring-boot-resilience4j</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-resilience4j-service2</artifactId>

--- a/rest-cxf-opentelemetry/pom.xml
+++ b/rest-cxf-opentelemetry/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-cxf-opentelemetry</artifactId>

--- a/rest-cxf-opentelemetry/rest-cxf-otel-common/pom.xml
+++ b/rest-cxf-opentelemetry/rest-cxf-otel-common/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-rest-cxf-opentelemetry</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-rest-cxf-otel-common</artifactId>

--- a/rest-cxf-opentelemetry/rest-cxf-otel-even/pom.xml
+++ b/rest-cxf-opentelemetry/rest-cxf-otel-even/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-rest-cxf-opentelemetry</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-rest-cxf-otel-even</artifactId>

--- a/rest-cxf-opentelemetry/rest-cxf-otel-odd/pom.xml
+++ b/rest-cxf-opentelemetry/rest-cxf-otel-odd/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-rest-cxf-opentelemetry</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-rest-cxf-otel-odd</artifactId>

--- a/rest-cxf-opentelemetry/rest-cxf-otel-random/pom.xml
+++ b/rest-cxf-opentelemetry/rest-cxf-otel-random/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-rest-cxf-opentelemetry</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-rest-cxf-otel-random</artifactId>

--- a/rest-cxf/pom.xml
+++ b/rest-cxf/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-cxf</artifactId>

--- a/rest-openapi-simple/pom.xml
+++ b/rest-openapi-simple/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-openapi-simple</artifactId>

--- a/rest-openapi-springdoc/pom.xml
+++ b/rest-openapi-springdoc/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-openapi-springdoc</artifactId>

--- a/rest-openapi/pom.xml
+++ b/rest-openapi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-rest-openapi</artifactId>

--- a/route-reload/pom.xml
+++ b/route-reload/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-route-reload</artifactId>

--- a/routes-configuration/pom.xml
+++ b/routes-configuration/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-routes-configuration</artifactId>

--- a/routetemplate-xml/pom.xml
+++ b/routetemplate-xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-routetemplate-xml</artifactId>

--- a/routetemplate/pom.xml
+++ b/routetemplate/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-routetemplate</artifactId>

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-saga</artifactId>

--- a/saga/saga-app/pom.xml
+++ b/saga/saga-app/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-saga</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-saga-app</artifactId>

--- a/saga/saga-flight-service/pom.xml
+++ b/saga/saga-flight-service/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-saga</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-saga-flight</artifactId>

--- a/saga/saga-payment-service/pom.xml
+++ b/saga/saga-payment-service/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-saga</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-saga-payment</artifactId>

--- a/saga/saga-train-service/pom.xml
+++ b/saga/saga-train-service/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>camel-example-spring-boot-saga</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-saga-train</artifactId>

--- a/soap-cxf/pom.xml
+++ b/soap-cxf/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>examples</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-soap-cxf</artifactId>

--- a/splitter-eip/pom.xml
+++ b/splitter-eip/pom.xml
@@ -24,7 +24,7 @@
 	<parent>
 		<artifactId>examples</artifactId>
 		<groupId>org.apache.camel.springboot.example</groupId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot</artifactId>

--- a/spring-jdbc/pom.xml
+++ b/spring-jdbc/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>examples</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-spring-jdbc</artifactId>

--- a/strimzi/pom.xml
+++ b/strimzi/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>examples</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-strimzi</artifactId>

--- a/supervising-route-controller/pom.xml
+++ b/supervising-route-controller/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-supervising-route-controller</artifactId>

--- a/tomcat-jdbc/pom.xml
+++ b/tomcat-jdbc/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-tomcat-jdbc</artifactId>

--- a/twitter-salesforce/pom.xml
+++ b/twitter-salesforce/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-twitter-salesforce</artifactId>

--- a/type-converter/pom.xml
+++ b/type-converter/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>examples</artifactId>
 		<groupId>org.apache.camel.springboot.example</groupId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/validator/pom.xml
+++ b/validator/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-validator</artifactId>

--- a/variables/pom.xml
+++ b/variables/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-variables</artifactId>

--- a/vault/pom.xml
+++ b/vault/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.apache.camel.springboot.example</groupId>
 		<artifactId>examples</artifactId>
-		<version>4.10.0-SNAPSHOT</version>
+		<version>4.11.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>camel-example-spring-boot-vault</artifactId>

--- a/webhook/pom.xml
+++ b/webhook/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.apache.camel.springboot.example</groupId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/widget-gadget/pom.xml
+++ b/widget-gadget/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>examples</artifactId>
         <groupId>org.apache.camel.springboot.example</groupId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/xml-import/pom.xml
+++ b/xml-import/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-xml-import</artifactId>

--- a/xml/pom.xml
+++ b/xml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.apache.camel.springboot.example</groupId>
         <artifactId>examples</artifactId>
-        <version>4.10.0-SNAPSHOT</version>
+        <version>4.11.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-example-spring-boot-xml</artifactId>


### PR DESCRIPTION
Upgrade the examples to 4.11.0-SNAPSHOT, use camel-version 4.11.0-SNAPSHOT and parent org.apache.camel.springboot:spring-boot 4.11.0-SNAPSHOT parent.

Ran mvn -DskipTests clean install; ran tests as well