### PR TITLE
jkube: replaces DeploymentConfig with Deployment CR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,8 +101,9 @@
 	<properties>
 		<camel-version>4.11.0-SNAPSHOT</camel-version>
 		<skip.starting.camel.context>false</skip.starting.camel.context>
-		<jkube-maven-plugin-version>1.17.0</jkube-maven-plugin-version>
+		<jkube-maven-plugin-version>1.18.1</jkube-maven-plugin-version>
 		<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
+		<jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
 		<kafka-avro-serializer-version>7.1.1</kafka-avro-serializer-version>
 		<reactor-version>3.7.0</reactor-version>
 		<testcontainers-version>1.20.4</testcontainers-version>

--- a/saga/ocp-resources/amq-broker-ephemeral.yaml
+++ b/saga/ocp-resources/amq-broker-ephemeral.yaml
@@ -20,7 +20,7 @@ items:
       targetPort: 61616
     selector:
       app: amq-broker
-      deploymentconfig: amq-broker
+      deployment: amq-broker
     type: ClusterIP
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
@@ -41,8 +41,8 @@ items:
       name: "latest"
       referencePolicy:
         type: Source
-- apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     generation: 1
     labels:
@@ -52,8 +52,9 @@ items:
   spec:
     replicas: 1
     selector:
-      app: amq-broker
-      deploymentconfig: amq-broker
+      matchLabels:
+        app: amq-broker
+        deployment: amq-broker
     strategy:
       type: Recreate
     template:
@@ -61,7 +62,7 @@ items:
         labels:
           app: amq-broker
           csbexample: saga
-          deploymentconfig: amq-broker
+          deployment: amq-broker
       spec:
         containers:
         - imagePullPolicy: IfNotPresent
@@ -91,16 +92,6 @@ items:
               port: 8161
               scheme: HTTP
             initialDelaySeconds: 10
-    triggers:
-    - type: ConfigChange
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - amq-broker
-        from:
-          kind: ImageStreamTag
-          name: "amq-broker:latest"
-      type: ImageChange
 - kind: Route
   apiVersion: route.openshift.io/v1
   metadata:

--- a/saga/ocp-resources/amq-broker.yaml
+++ b/saga/ocp-resources/amq-broker.yaml
@@ -20,7 +20,7 @@ items:
       targetPort: 61616
     selector:
       app: amq-broker
-      deploymentconfig: amq-broker
+      deployment: amq-broker
     type: ClusterIP
 - apiVersion: v1
   kind: PersistentVolumeClaim
@@ -48,14 +48,14 @@ items:
     tags:
     - from:
         kind: DockerImage
-        name: registry.redhat.io/amq7/amq-broker-rhel8:7.11.0
+        name: registry.redhat.io/amq7/amq-broker-rhel8:7.12
       generation: 0
       importPolicy: {}
       name: "latest"
       referencePolicy:
         type: Source
-- apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     generation: 1
     labels:
@@ -65,8 +65,9 @@ items:
   spec:
     replicas: 1
     selector:
-      app: amq-broker
-      deploymentconfig: amq-broker
+      matchLabels:
+        app: amq-broker
+        deployment: amq-broker
     strategy:
       type: Recreate
     template:
@@ -74,7 +75,7 @@ items:
         labels:
           app: amq-broker
           csbexample: saga
-          deploymentconfig: amq-broker
+          deployment: amq-broker
       spec:
         containers:
         - imagePullPolicy: IfNotPresent
@@ -113,16 +114,6 @@ items:
         - name: amq-broker-data
           persistentVolumeClaim:
             claimName: amq-broker
-    triggers:
-    - type: ConfigChange
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - amq-broker
-        from:
-          kind: ImageStreamTag
-          name: "amq-broker:latest"
-      type: ImageChange
 - kind: Route
   apiVersion: route.openshift.io/v1
   metadata:

--- a/saga/ocp-resources/lra-coordinator-ephemeral.yaml
+++ b/saga/ocp-resources/lra-coordinator-ephemeral.yaml
@@ -16,7 +16,7 @@ items:
       targetPort: 8080
     selector:
       app: lra-coordinator
-      deploymentconfig: lra-coordinator
+      deployment: lra-coordinator
     type: ClusterIP
 - apiVersion: image.openshift.io/v1
   kind: ImageStream
@@ -37,8 +37,8 @@ items:
       name: "latest"
       referencePolicy:
         type: Source
-- apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     generation: 1
     labels:
@@ -48,8 +48,9 @@ items:
   spec:
     replicas: 1
     selector:
-      app: lra-coordinator
-      deploymentconfig: lra-coordinator
+      matchLabels:
+        app: lra-coordinator
+        deployment: lra-coordinator
     strategy:
       type: Recreate
     template:
@@ -57,10 +58,11 @@ items:
         labels:
           app: lra-coordinator
           csbexample: saga
-          deploymentconfig: lra-coordinator
+          deployment: lra-coordinator
       spec:
         containers:
         - imagePullPolicy: IfNotPresent
+          image: "lra-coordinator:latest"
           env:
           - name: AB_JOLOKIA_OFF
             value: "true"
@@ -86,13 +88,3 @@ items:
         volumes:
           - name: lra-coordinator-data
             emptyDir: {}
-    triggers:
-    - type: ConfigChange
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - lra-coordinator
-        from:
-          kind: ImageStreamTag
-          name: "lra-coordinator:latest"
-      type: ImageChange

--- a/saga/ocp-resources/lra-coordinator.yaml
+++ b/saga/ocp-resources/lra-coordinator.yaml
@@ -16,7 +16,7 @@ items:
       targetPort: 8080
     selector:
       app: lra-coordinator
-      deploymentconfig: lra-coordinator
+      deployment: lra-coordinator
     type: ClusterIP
 - apiVersion: v1
   kind: PersistentVolumeClaim
@@ -50,8 +50,8 @@ items:
       name: "latest"
       referencePolicy:
         type: Source
-- apiVersion: apps.openshift.io/v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     generation: 1
     labels:
@@ -61,8 +61,9 @@ items:
   spec:
     replicas: 1
     selector:
-      app: lra-coordinator
-      deploymentconfig: lra-coordinator
+      matchLabels:
+        app: lra-coordinator
+        deployment: lra-coordinator
     strategy:
       type: Recreate
     template:
@@ -70,10 +71,11 @@ items:
         labels:
           app: lra-coordinator
           csbexample: saga
-          deploymentconfig: lra-coordinator
+          deployment: lra-coordinator
       spec:
         containers:
         - imagePullPolicy: IfNotPresent
+          image: "lra-coordinator:latest"
           env:
           - name: AB_JOLOKIA_OFF
             value: "true"
@@ -100,13 +102,3 @@ items:
         - name: lra-coordinator-data
           persistentVolumeClaim:
             claimName: lra-coordinator
-    triggers:
-    - type: ConfigChange
-    - imageChangeParams:
-        automatic: true
-        containerNames:
-        - lra-coordinator
-        from:
-          kind: ImageStreamTag
-          name: "lra-coordinator:latest"
-      type: ImageChange

--- a/saga/pom.xml
+++ b/saga/pom.xml
@@ -134,15 +134,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>openshift-maven-plugin</artifactId>
-                    <groupId>org.eclipse.jkube</groupId>
-                    <version>${jkube-maven-plugin-version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>

--- a/saga/readme.adoc
+++ b/saga/readme.adoc
@@ -156,7 +156,7 @@ tail logs of the application:
 
 [source,shell]
 ----
-oc logs -f deploymentconfig/camel-example-spring-boot-saga-payment
+oc logs -f deployment/camel-example-spring-boot-saga-payment
 ----
 
 === Running on local environment


### PR DESCRIPTION
Since DeploymentConfig has been deprecated we should use Deployment instead, and by default JKube maven plugin should be set to avoid DeploymentConfig generation on OpenShift using the property [jkube.build.switchToDeployment](https://eclipse.dev/jkube/docs/openshift-maven-plugin/#jkube-openshift-deploymentconfig)