### PR TITLE
Bump dependency versions to align with Camel parent

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -27,7 +27,7 @@ readme's instructions.
 === Examples
 
 // examples: START
-Number of Examples: 70 (0 deprecated)
+Number of Examples: 71 (0 deprecated)
 
 [width="100%",cols="4,2,4",options="header"]
 |===

--- a/pom.xml
+++ b/pom.xml
@@ -111,14 +111,14 @@
 		<camel-version>4.19.0-SNAPSHOT</camel-version>
     	<javaVersion>21</javaVersion>
 		<skip.starting.camel.context>false</skip.starting.camel.context>
-		<jkube-maven-plugin-version>1.18.1</jkube-maven-plugin-version>
+		<jkube-maven-plugin-version>1.19.0</jkube-maven-plugin-version>
 		<jkube.generator.from>registry.access.redhat.com/ubi9/openjdk-17:latest</jkube.generator.from>
 		<jkube.build.switchToDeployment>true</jkube.build.switchToDeployment>
-		<kafka-avro-serializer-version>7.1.1</kafka-avro-serializer-version>
-		<reactor-version>3.7.0</reactor-version>
+		<kafka-avro-serializer-version>7.8.2</kafka-avro-serializer-version>
+		<reactor-version>3.8.3</reactor-version>
 		<testcontainers-version>2.0.3</testcontainers-version>
-		<hapi-structures-v24-version>2.5.1</hapi-structures-v24-version>
-		<artemis-jakarta-version>2.38.0</artemis-jakarta-version>
+		<hapi-structures-v24-version>2.6.0</hapi-structures-v24-version>
+		<artemis-jakarta-version>2.44.0</artemis-jakarta-version>
 	</properties>
 
 	<repositories>


### PR DESCRIPTION
## Summary
- Update `jkube-maven-plugin-version` 1.18.1 → 1.19.0
- Update `kafka-avro-serializer-version` 7.1.1 → 7.8.2
- Update `reactor-version` 3.7.0 → 3.8.3 (aligned with Camel parent)
- Update `hapi-structures-v24-version` 2.5.1 → 2.6.0 (aligned with Camel parent)
- Update `artemis-jakarta-version` 2.38.0 → 2.44.0 (aligned with Camel parent)

## Test plan
- [x] Full build with `mvn install -DskipTests` passes