### PR TITLE
Fix arangodb and kafka-offsetrepository examples

### DIFF
--- a/arangodb/src/main/java/org/apache/camel/example/springboot/arangodb/CamelRoute.java
+++ b/arangodb/src/main/java/org/apache/camel/example/springboot/arangodb/CamelRoute.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.example.springboot.arangodb;
 
+import com.arangodb.entity.BaseDocument;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.component.arangodb.ArangoDbConstants;
 import org.springframework.stereotype.Component;
@@ -30,7 +31,7 @@ public class CamelRoute extends RouteBuilder {
                 .bean(MyBeanService.class, "createDocument")
                 .to("arangodb:myDatabase?operation=SAVE_DOCUMENT")
                 .bean(MyBeanService.class, "readDocument")
-                .setHeader(ArangoDbConstants.RESULT_CLASS_TYPE).constant(String.class)
+                .setHeader(ArangoDbConstants.RESULT_CLASS_TYPE).constant(BaseDocument.class)
                 .to("arangodb:myDatabase?operation=FIND_DOCUMENT_BY_KEY")
                 .log("Received body: ${body}");
     }

--- a/arangodb/src/main/resources/application.properties
+++ b/arangodb/src/main/resources/application.properties
@@ -16,6 +16,8 @@
 ## ---------------------------------------------------------------------------
 camel.main.name=ArangoDB
 camel.main.run-controller=true
+camel.component.arangodb.host=localhost
+camel.component.arangodb.port=8529
 camel.component.arangodb.documentCollection=myCollection
 camel.component.arangodb.user=root
 camel.component.arangodb.password=password

--- a/kafka-offsetrepository/src/main/resources/spring/camel-context.xml
+++ b/kafka-offsetrepository/src/main/resources/spring/camel-context.xml
@@ -57,7 +57,7 @@
             <setBody id="route-setBody-1">
                 <simple>This is first producer: ${id}</simple>
             </setBody>
-            <to id="_kafka1" uri="kafka:{{producer.topic}}?partitionKey={{partitionValue}}&amp;key=${id}"/>
+            <to id="_kafka1" uri="kafka:{{producer.topic}}?partitionKey={{partitionValue}}&amp;key=${id}&amp;recordMetadata=true"/>
             <log id="route-log-producer-1" message="producer >>> ${body}"/>
             <bean id="_bean1" ref="kafkaProcessor"/>
         </route>


### PR DESCRIPTION
## Summary
- **arangodb**: Add explicit `host=localhost` and `port=8529` config (required since ArangoDB driver 7.24+) and use `BaseDocument.class` instead of `String.class` for `FIND_DOCUMENT_BY_KEY` result type (Jackson 2.21 no longer coerces JSON objects to String)
- **kafka-offsetrepository**: Add `recordMetadata=true` to Kafka producer endpoint (default changed from `true` to `false`)

## Test plan
- [x] Start ArangoDB via `camel infra run arangodb`, run example, verify document is saved and retrieved
- [x] Start Kafka via `camel infra run kafka`, run example, verify producer logs partition metadata