### PR TITLE
CAMEL-23655: Update GitHub topics for better discoverability

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -20,9 +20,19 @@ github:
   homepage: https://camel.apache.org
   labels:
     - camel
-    - integration
-    - java
+    - examples
     - spring-boot
+    - integration
+    - integration-framework
+    - enterprise-integration-patterns
+    - java
+    - cloud-native
+    - kafka
+    - rest-api
+    - yaml
+    - data-transformation
+    - microservices
+    - mcp
   enabled_merge_buttons:
     merge: false
     rebase: true


### PR DESCRIPTION
## Summary

- Expand GitHub topics from 4 to 14 (out of 20 max) to improve discoverability
- Add `examples` to identify this as a samples/examples repository
- Add `integration-framework`, `enterprise-integration-patterns`
- Add deployment/ecosystem: `cloud-native`, `kafka`
- Add capabilities: `rest-api`, `yaml`, `data-transformation`
- Add `microservices`, `mcp`

Follows the same topic expansion done in apache/camel#23673.

## Test plan

- [ ] After merge, verify topics appear on https://github.com/apache/camel-spring-boot-examples

_Claude Code on behalf of Claus Ibsen_