### PR TITLE
Configure GitHub workflow to cancel previous PR check in case of new

### DIFF
--- a/.github/workflows/master-pr-build.yml
+++ b/.github/workflows/master-pr-build.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches:
       - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 jobs:
   build:
     if: github.repository == 'apache/camel-spring-boot-examples'


### PR DESCRIPTION
commits on same PR

It will save some resources in case of new commit on a branch PR and PR checks were not finished
Apache committers can see recommendations here
https://cwiki.apache.org/confluence/pages/viewpage.action?spaceKey=INFRA&title=GitHub+Actions+Recommended+Practices