### PR TITLE
CAMEL-23135: upgrade remaining quickstarts to use camel-jackson3-starter

### DIFF
--- a/milvus/pom.xml
+++ b/milvus/pom.xml
@@ -89,7 +89,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-jackson-starter</artifactId>
+            <artifactId>camel-jackson3-starter</artifactId>
         </dependency>
 
         <!-- test -->

--- a/qdrant/pom.xml
+++ b/qdrant/pom.xml
@@ -89,7 +89,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.camel.springboot</groupId>
-            <artifactId>camel-jackson-starter</artifactId>
+            <artifactId>camel-jackson3-starter</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Updating
  `milvus/pom.xml`
  `qdrant/pom.xml`

to use `camel-jackson3-starter` instead of `camel-jackson-starter`. All other quickstarts that use Jackson are already at version 3.